### PR TITLE
Update default.glsl

### DIFF
--- a/src/main/resources/hydrogenShaders/vertex/default.glsl
+++ b/src/main/resources/hydrogenShaders/vertex/default.glsl
@@ -1,38 +1,50 @@
 #version 450 core
-layout (location = 0) in vec3 vertexPos;
-layout (location = 1) in vec3 vertexNormal;
-layout (location = 2) in vec2 vertexTexCoord;
 
-uniform mat4 transformMatrix;
-uniform mat4 viewMatrix;
-uniform mat4 projectionMatrix;
+// Input vertex attributes
+layout (location = 0) in vec3 in_vertexPosition; // Renamed for clarity
+layout (location = 1) in vec3 in_vertexNormal;   // Renamed for clarity
+layout (location = 2) in vec2 in_texCoord;       // Renamed for clarity
 
-out vec3 pos;
-out vec3 normal;
-out vec2 texCoord;
+// --- UNIFORMS ---
+// It's often more efficient to compute combined matrices on the CPU
+uniform mat4 u_modelMatrix;        // Renamed from transformMatrix (Model -> World)
+uniform mat4 u_viewProjectionMatrix; // Combined View * Projection matrix (World -> Clip Space)
+                                     // Calculated on CPU: projectionMatrix * viewMatrix
 
-out vec3 fragmentWorldPos;
+// Optional: Pass normal matrix if non-uniform scaling is used.
+// Calculated on CPU: transpose(inverse(mat3(u_modelMatrix)))
+uniform mat3 u_normalMatrix;
 
-out vec3 toCameraDir;
+// Pass camera position calculated on the CPU
+// Calculated on CPU: inverse(viewMatrix)[3].xyz or similar method
+uniform vec3 u_cameraWorldPos;
+
+// --- OUTPUTS to Fragment Shader ---
+out vec3 vs_out_worldPos;    // Vertex position in world space
+out vec3 vs_out_normal;      // Vertex normal in world space (normalized)
+out vec2 vs_out_texCoord;    // Texture coordinates
+out vec3 vs_out_toCameraDir; // Direction from vertex to camera (normalized)
 
 void main() {
-    // Compute the world position
-    vec4 worldPos = transformMatrix * vec4(vertexPos, 1.0);
+    // Calculate world position
+    vec4 worldPos4 = u_modelMatrix * vec4(in_vertexPosition, 1.0);
+    vs_out_worldPos = worldPos4.xyz; // Pass only vec3
 
-    // Compute the position of the camera in world space
-    vec4 cameraWorldPos = inverse(viewMatrix) * vec4(0, 0, 0, 1);
+    // Calculate final clip space position using pre-combined matrix
+    gl_Position = u_viewProjectionMatrix * worldPos4;
 
-    // Compute the final position in clip space
-    vec4 clipSpacePos = projectionMatrix * viewMatrix * worldPos;
-    gl_Position = clipSpacePos;
+    // Transform normal to world space using the normal matrix and normalize
+    // Normalization is important as interpolation in fragment shader can change length
+    // Use u_normalMatrix (inverse transpose) for correctness with non-uniform scaling.
+    // If only uniform scaling/rotation, mat3(u_modelMatrix) could be used (faster).
+    vs_out_normal = normalize(u_normalMatrix * in_vertexNormal);
 
-    // Pass through vertex attributes
-    pos = vertexPos;
-    normal = mat3(transpose(inverse(transformMatrix))) * vertexNormal;
-    texCoord = vertexTexCoord;
+    // Pass texture coordinates through
+    vs_out_texCoord = in_texCoord;
 
-   fragmentWorldPos = worldPos.xyz;
+    // Calculate normalized direction vector from fragment to camera (in world space)
+    vs_out_toCameraDir = normalize(u_cameraWorldPos - vs_out_worldPos);
 
-    // Calculate the direction to the camera
-    toCameraDir = cameraWorldPos.xyz - worldPos.xyz;
+    // Removed the 'out vec3 pos;' as its purpose (passing local vertexPos) was unclear
+    // and potentially redundant given vs_out_worldPos.
 }


### PR DESCRIPTION
Input/Output Naming: Prefixed inputs with in_ and outputs with vs_out_ for better readability and clarity about data flow (common practice). vertexPos -> in_vertexPosition, etc. Matrix Uniforms:
transformMatrix renamed to u_modelMatrix (more standard name). Introduced u_viewProjectionMatrix. Calculating projection * view once per frame on the CPU is much more efficient than projection * view * worldPos per vertex. Introduced u_normalMatrix. Calculating transpose(inverse(mat3(modelMatrix))) on the CPU (once per object using the model matrix) is significantly faster than doing transpose(inverse(transformMatrix)) per vertex. Note: If you are certain your model matrix only contains rotation and uniform scaling, you could simplify this on the CPU and shader side to just use mat3(u_modelMatrix). Camera Position Uniform: Introduced u_cameraWorldPos. Calculating inverse(viewMatrix) just to get the camera position is very expensive per vertex. Calculate the camera's world position once per frame on the CPU and pass it as a uniform. Efficiency: Replaced expensive per-vertex matrix multiplications (projection * view * worldPos) and inversions (inverse(viewMatrix), inverse(transformMatrix)) with uniforms calculated less frequently on the CPU. Normalization: Explicitly normalized vs_out_normal and vs_out_toCameraDir. This is crucial because the rasterizer interpolates these values, and interpolation does not preserve vector length. Normalizing here ensures the fragment shader receives vectors that are ready for lighting calculations (or can be easily re-normalized if needed). Removed Redundant Output: Removed the out vec3 pos; which was simply passing the original vertexPos (local model space). This is rarely needed in the fragment shader, especially when world position (vs_out_worldPos) is already being passed. If you did need the local position for some specific effect, you could add it back, but it's generally not standard. Clarity: fragmentWorldPos renamed to vs_out_worldPos for consistency. To use this shader:

Your CPU-side code now needs to calculate and upload u_modelMatrix, u_viewProjectionMatrix, u_normalMatrix, and u_cameraWorldPos as uniforms.